### PR TITLE
Make setBit static for compiler optimistations

### DIFF
--- a/64/mem/pmm.c
+++ b/64/mem/pmm.c
@@ -93,7 +93,7 @@ void initPMM(struct limine_memmap_request memmapRequest) {
 }
 
 // just a basic utility
-uint8_t setBit(uint8_t byte, uint8_t bitPosition) {
+static uint8_t setBit(uint8_t byte, uint8_t bitPosition) {
     if (bitPosition < 8) {
         return byte |= (1 << bitPosition);
     }


### PR DESCRIPTION
Made setBit static so the compiler can inline and or remove the function entirely if it decides to do so.